### PR TITLE
changed keppler admin default email

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,7 @@
 end
 
 User.create(
-  name: 'Keppler Admin', email: 'admin@keppler.io', password: '+12345678+',
+  name: 'Keppler Admin', email: 'admin@keppleradmin.com', password: '+12345678+',
   password_confirmation: '+12345678+', role_ids: '1'
 )
 
@@ -44,7 +44,7 @@ puts 'Setting default has been created'
 
 if defined?(KepplerContactUs) && KepplerContactUs.is_a?(Class)
   KepplerContactUs::MessageSetting.create(
-    mailer_from: 'contacto@slicegroup.xyz', 
+    mailer_from: 'contacto@slicegroup.xyz',
     mailer_to: 'contacto@slicegroup.xyz'
   )
   puts 'KepplerContactUs mailer_to and mailer_from has been created'


### PR DESCRIPTION
Solved issue #279 

Cambiado `admin@keppler.io` por `admin@keppleradmin.com`